### PR TITLE
パーティのステータスの表示形式の改善[谷口智哉]

### DIFF
--- a/src/rpg/character/hero/HeroParty.java
+++ b/src/rpg/character/hero/HeroParty.java
@@ -20,7 +20,7 @@ public class HeroParty extends AbstractParty{
 		for(AbstractCharacter member: super.getMembers()) {
 			Hero hero = (Hero) member;
 			if(hero.getHp() > 0  && !hero.isEscaped()) {
-				System.out.print(hero.getName() + ")" + hero.getJob() + "(;" + hero.getHp() + " ");
+				System.out.print(hero.getName() + "(職業:" + hero.getJob() + " HP:" + hero.getHp() + ") ");
 			}else if(member.isEscaped()) {
 				System.out.println(hero.getName() + "(" + hero.getJob() + "):死亡 ");
 			}else if(member.getHp() <= 0) {


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/RPG_Java/issues/6

### 対応内容（何に取り組んだか）
パーティのステータスの表示形式について、以下の改善を行った。
・括弧の修正とセミコロンの削除
・職業とHPのステータスのラベル付け

### 対応方法(どう対処したか具体的に)
RPG_Java/src/rpg/character/hero/HeroParty.java内の23行目を以下のように変更した。
System.out.print(hero.getName() + "(職業:" + hero.getJob() + " HP:" + hero.getHp() + ") ");


### レビューしてほしい点（工夫点など）
ラベル付けを行ったことでパーティメンバーの各ステータスの指す意味が明確になった。
***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [x] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [x] レビューアをアサインしましたか（右上のReviewersにOTOYO1020を設定してください）
- [x] 適切にコメントしていますか
