### PR TITLE
「死亡」と「逃亡」の表記の修正[徳元聖也]

### DIFF
--- a/src/rpg/character/hero/HeroParty.java
+++ b/src/rpg/character/hero/HeroParty.java
@@ -22,9 +22,9 @@ public class HeroParty extends AbstractParty{
 			if(hero.getHp() > 0  && !hero.isEscaped()) {
 				System.out.print(hero.getName() + ")" + hero.getJob() + "(;" + hero.getHp() + " ");
 			}else if(member.isEscaped()) {
-				System.out.println(hero.getName() + "(" + hero.getJob() + "):死亡 ");
+				System.out.println(hero.getName() + "(" + hero.getJob() + "):逃亡 ");// 死亡→逃亡に修正
 			}else if(member.getHp() <= 0) {
-				System.out.println(hero.getName() + "(" + hero.getJob() + "):逃亡 ");
+				System.out.println(hero.getName() + "(" + hero.getJob() + "):死亡 ");// 逃亡→死亡に修正
 			}
 		}
 		System.out.println();  //レイアウト調整のための改行


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/RPG_Java/issues/18

### 対応内容（何に取り組んだか）
死亡した時に「逃亡」、逃亡した時に「死亡」と表示されるようになっていたので修正した。

### 対応方法(どう対処したか具体的に)
ステータスの表示を条件(死亡や逃亡)に合うようにした。

### レビューしてほしい点（工夫点など）
条件にあうように表示を変更した。

***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [x] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [x] レビューアをアサインしましたか（右上のReviewersにOTOYO1020を設定してください）
- [x] 適切にコメントしていますか
