### PR TITLE
ボスが必殺技を使用するように変更 [田井聖凪]

### DIFF
--- a/src/rpg/character/hero/Hero.java
+++ b/src/rpg/character/hero/Hero.java
@@ -9,7 +9,7 @@ public class Hero extends AbstractCharacter {
 	protected String job;
 	
 	public Hero(String name, int hp, int attack){
-		super(name, hp, attack);
+		super(name, 10 * hp, attack);
 		this.job = "普通のヒーロー";
 	}
 	

--- a/src/rpg/character/monster/Monster.java
+++ b/src/rpg/character/monster/Monster.java
@@ -7,7 +7,7 @@ import rpg.character.AbstractParty;
 
 public abstract class Monster extends AbstractCharacter{
 	public Monster(String name, int hp, int attack) {
-		super(name, attack, hp);
+		super(name, hp, attack);
 	}
 	
 	protected void command(AbstractParty ally, AbstractParty enemies) {

--- a/src/rpg/character/monster/monster/BossMonster.java
+++ b/src/rpg/character/monster/monster/BossMonster.java
@@ -1,10 +1,40 @@
 package rpg.character.monster.monster;
 
+import java.util.Random;
+
 import rpg.character.Specialist;
 import rpg.character.monster.Monster;
+
+import rpg.character.AbstractCharacter;
+import rpg.character.AbstractParty;
 
 public abstract class BossMonster extends Monster implements Specialist{
 	public BossMonster(String name, int hp, int attack) {
 		super(name, hp, attack);
+	}
+
+	protected void command(AbstractParty ally, AbstractParty enemies) {
+		System.out.println(super.getName() + "の行動");
+		Random random = new Random();
+		int command = random.nextInt(2);  
+		if(command == 0) {
+			while(true) {
+				if(super.attack(enemies)) {
+					break;
+				}else {
+					this.command(ally, enemies);
+				}
+			}
+		}else if(command == 1){
+			while(true) {
+				if(this.special(enemies)) {
+					break;
+				}else {
+					this.command(ally, enemies);
+				}
+			}
+		}else{
+			this.command(ally, enemies);
+		}
 	}
 }


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/RPG_Java/issues/23

### 対応内容（何に取り組んだか）
 ボスが固有の必殺技を使用するように修正した

### 対応方法(どう対処したか具体的に)
 BossMonsterクラスにおいて、AbstractCharacterから継承したcommandメソッドを変更
 乱数を用いて、呼び起す処理を通常攻撃(attackメソッド)と必殺技(specialメソッド)に振り分けることで、ボスが必殺技を使用できるようにした。

### レビューしてほしい点（工夫点など）
 commandメソッドをBossMonster用に上書きすることで、一般モンスターには影響を及ぼさないようにした点
***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [ ] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [ ] レビューアをアサインしましたか（右上のReviewersにOTOYO1020を設定してください）
- [ ] 適切にコメントしていますか
